### PR TITLE
Remove pry-byebug require statement and add gemspec dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,3 @@
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in helm.gemspec
 gemspec
-
-gem "rake", "~> 12.0"
-gem "minitest", "~> 5.0"
-gem "pry-byebug"

--- a/lib/rhelm/subcommand_proxy.rb
+++ b/lib/rhelm/subcommand_proxy.rb
@@ -1,5 +1,4 @@
 require 'open3'
-require 'pry-byebug'
 
 module Rhelm
   class Client

--- a/lib/rhelm/version.rb
+++ b/lib/rhelm/version.rb
@@ -1,4 +1,4 @@
 
 module Rhelm
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/rhelm.gemspec
+++ b/rhelm.gemspec
@@ -26,4 +26,10 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake', '>= 12'
+  spec.add_development_dependency 'minitest', '~> 5.0'
 end


### PR DESCRIPTION
This PR:
* removes a stray "pry-byebug" statement
* specifies development dependencies in the gemspec
* removes explicit development dependencies from Gemfile - this should not be necessary, as these dependencies are all fetched from Rubygems, which is the default source in the Gemfile.
* bumps the version.